### PR TITLE
add ability to set host

### DIFF
--- a/src/main/java/de/sldk/mc/PluginConfig.java
+++ b/src/main/java/de/sldk/mc/PluginConfig.java
@@ -4,6 +4,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 
 class PluginConfig<T> {
 
+    static final PluginConfig<String> HOST = new PluginConfig<>("host", "localhost");
     static final PluginConfig<Integer> PORT = new PluginConfig<>("port", 9225);
     static final PluginConfig<Boolean> PLAYER_METRICS = new PluginConfig<>("individual-player-statistics", false);
 

--- a/src/main/java/de/sldk/mc/PluginConfig.java
+++ b/src/main/java/de/sldk/mc/PluginConfig.java
@@ -4,7 +4,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 
 class PluginConfig<T> {
 
-    static final PluginConfig<String> HOST = new PluginConfig<>("host", "localhost");
+    static final PluginConfig<String> HOST = new PluginConfig<>("host", "0.0.0.0");
     static final PluginConfig<Integer> PORT = new PluginConfig<>("port", 9225);
     static final PluginConfig<Boolean> PLAYER_METRICS = new PluginConfig<>("individual-player-statistics", false);
 

--- a/src/main/java/de/sldk/mc/PrometheusExporter.java
+++ b/src/main/java/de/sldk/mc/PrometheusExporter.java
@@ -5,6 +5,8 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jetty.server.Server;
 
+import java.net.InetSocketAddress;
+
 public class PrometheusExporter extends JavaPlugin {
 
     FileConfiguration config = getConfig();
@@ -19,6 +21,7 @@ public class PrometheusExporter extends JavaPlugin {
                 .getScheduler()
                 .scheduleSyncRepeatingTask(this, tpsPoller, 0, TpsPoller.POLL_INTERVAL);
 
+        PluginConfig.HOST.setDefault(config);
         PluginConfig.PORT.setDefault(config);
         PluginConfig.PLAYER_METRICS.setDefault(config);
 
@@ -26,19 +29,20 @@ public class PrometheusExporter extends JavaPlugin {
         saveConfig();
 
         int port = PluginConfig.PORT.get(config);
+        String host = PluginConfig.HOST.get(config);
         boolean individualPlayerMetrics = PluginConfig.PLAYER_METRICS.get(config);
 
         if (individualPlayerMetrics) {
             getLogger().warning("Flag '" + PluginConfig.PLAYER_METRICS.getKey() + "' is enabled. This option is not recommended for public servers!");
         }
 
-        server = new Server(port);
+        InetSocketAddress address = new InetSocketAddress(host, port);
+        server = new Server(address);
         server.setHandler(new MetricsController(this, individualPlayerMetrics));
 
         try {
             server.start();
-
-            getLogger().info("Started Prometheus metrics endpoint on port " + port);
+            getLogger().info("Started Prometheus metrics endpoint at: " + host + ":" + port);
 
         } catch (Exception e) {
             getLogger().severe("Could not start embedded Jetty server");


### PR DESCRIPTION
Hi,

this PR adds the ability to set the hostname (eg. IP) of the exporter. 
It defaults to `localhost`.