### PR TITLE
More JVM metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.iml
 /.idea/
 /target/
+.settings
+.classpath
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .settings
 .classpath
 .project
+.vscode

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ mc_players_online_total | Online players per world
 mc_entities_total | Entities loaded per world
 mc_living_entities_total | Living entities loaded per world
 mc_jvm_memory | JVM memory usage
+mc_jvm_threads | JVM threads info
 mc_tps | Server tickrate (TPS)
 
 ## Player metrics (experimental!)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <bukkit.version>1.15.1-R0.1-SNAPSHOT</bukkit.version>
         <jetty.version>9.4.25.v20191220</jetty.version>
-        <prometheus-client.version>0.8.0</prometheus-client.version>
+        <prometheus-client.version>0.8.1</prometheus-client.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
     </properties>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_hotspot</artifactId>
-            <version>0.8.1</version>
+            <version>${prometheus-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>${prometheus-client.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.8.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>

--- a/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
+++ b/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
@@ -1,14 +1,26 @@
 package de.sldk.mc.config;
 
-import de.sldk.mc.MetricRegistry;
-import de.sldk.mc.PrometheusExporter;
-import de.sldk.mc.metrics.*;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.Plugin;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.Plugin;
+
+import de.sldk.mc.MetricRegistry;
+import de.sldk.mc.PrometheusExporter;
+import de.sldk.mc.metrics.Entities;
+import de.sldk.mc.metrics.GarbageCollectorWrapper;
+import de.sldk.mc.metrics.LivingEntities;
+import de.sldk.mc.metrics.LoadedChunks;
+import de.sldk.mc.metrics.Memory;
+import de.sldk.mc.metrics.Metric;
+import de.sldk.mc.metrics.PlayerOnline;
+import de.sldk.mc.metrics.PlayerStatistics;
+import de.sldk.mc.metrics.PlayersOnlineTotal;
+import de.sldk.mc.metrics.PlayersTotal;
+import de.sldk.mc.metrics.ThreadsWrapper;
+import de.sldk.mc.metrics.Tps;
 
 public class PrometheusExporterConfig {
 
@@ -22,6 +34,9 @@ public class PrometheusExporterConfig {
             metricConfig("players_online_total", true, PlayersOnlineTotal::new),
             metricConfig("players_total", true, PlayersTotal::new),
             metricConfig("tps", true, Tps::new),
+
+            metricConfig("jvm_threads", true, ThreadsWrapper::new),
+            metricConfig("jvm_gc", true, GarbageCollectorWrapper::new),
 
             metricConfig("player_online", false, PlayerOnline::new),
             metricConfig("player_statistic", false, PlayerStatistics::new));

--- a/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
+++ b/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
@@ -1,12 +1,10 @@
 package de.sldk.mc.metrics;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.plugin.Plugin;
 
 import io.prometheus.client.Collector;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.hotspot.GarbageCollectorExports;
 
 public class GarbageCollectorWrapper extends Metric {
@@ -22,15 +20,7 @@ public class GarbageCollectorWrapper extends Metric {
 
         @Override
         public List<MetricFamilySamples> collect() {
-            MetricFamilySamples collected = garbageCollectorExports.collect().get(0);
-            List<Sample> samples = new ArrayList<>(collected.samples.size());
-            for(Sample sample : collected.samples) {
-                samples.add(new Sample(prefix(sample.name), sample.labelNames, sample.labelValues, sample.value));
-            }
-            MetricFamilySamples prefixed = new MetricFamilySamples(prefix(collected.name), collected.type, collected.help, samples);
-            List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
-            mfs.add(prefixed);
-            return mfs;
+            return HotspotPrefixer.prefixFromCollector(garbageCollectorExports);
         }
     }
 }

--- a/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
+++ b/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
@@ -1,0 +1,36 @@
+package de.sldk.mc.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.hotspot.GarbageCollectorExports;
+
+public class GarbageCollectorWrapper extends Metric {
+    public GarbageCollectorWrapper(Plugin plugin) {
+        super(plugin, new GarbageCollectorWrapper.GarbageCollectorExportsCollector());
+    }
+
+    @Override
+    protected void doCollect() {}
+
+    private static class GarbageCollectorExportsCollector extends Collector {
+        private static final GarbageCollectorExports garbageCollectorExports = new GarbageCollectorExports();
+
+        @Override
+        public List<MetricFamilySamples> collect() {
+            MetricFamilySamples collected = garbageCollectorExports.collect().get(0);
+            List<Sample> samples = new ArrayList<>(collected.samples.size());
+            for(Sample sample : collected.samples) {
+                samples.add(new Sample(prefix(sample.name), sample.labelNames, sample.labelValues, sample.value));
+            }
+            MetricFamilySamples prefixed = new MetricFamilySamples(prefix(collected.name), collected.type, collected.help, samples);
+            List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+            mfs.add(prefixed);
+            return mfs;
+        }
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
+++ b/src/main/java/de/sldk/mc/metrics/GarbageCollectorWrapper.java
@@ -11,7 +11,7 @@ import io.prometheus.client.hotspot.GarbageCollectorExports;
 
 public class GarbageCollectorWrapper extends Metric {
     public GarbageCollectorWrapper(Plugin plugin) {
-        super(plugin, new GarbageCollectorWrapper.GarbageCollectorExportsCollector());
+        super(plugin, new GarbageCollectorExportsCollector());
     }
 
     @Override

--- a/src/main/java/de/sldk/mc/metrics/HotspotPrefixer.java
+++ b/src/main/java/de/sldk/mc/metrics/HotspotPrefixer.java
@@ -1,0 +1,26 @@
+package de.sldk.mc.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+
+public final class HotspotPrefixer {
+    protected static List<MetricFamilySamples> prefixFromCollector(Collector collector) {
+        List<MetricFamilySamples> collected = collector.collect();
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+
+        for (MetricFamilySamples mSample : collected) {
+            List<Sample> samples = new ArrayList<>(mSample.samples.size());
+            for (Sample sample : mSample.samples) {
+                samples.add(new Sample(Metric.prefix(sample.name), sample.labelNames, sample.labelValues, sample.value));
+            }
+
+            MetricFamilySamples prefixed = new MetricFamilySamples(Metric.prefix(mSample.name), mSample.type, mSample.help, samples);
+            mfs.add(prefixed);
+        }
+        return mfs;
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/Memory.java
+++ b/src/main/java/de/sldk/mc/metrics/Memory.java
@@ -19,5 +19,6 @@ public class Memory extends Metric {
     public void doCollect() {
         MEMORY.labels("max").set(Runtime.getRuntime().maxMemory());
         MEMORY.labels("free").set(Runtime.getRuntime().freeMemory());
+        MEMORY.labels("allocated").set(Runtime.getRuntime().totalMemory());
     }
 }

--- a/src/main/java/de/sldk/mc/metrics/ThreadsWrapper.java
+++ b/src/main/java/de/sldk/mc/metrics/ThreadsWrapper.java
@@ -1,0 +1,39 @@
+package de.sldk.mc.metrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.hotspot.ThreadExports;
+
+public class ThreadsWrapper extends Metric {
+    public ThreadsWrapper(Plugin plugin) {
+        super(plugin, new ThreadExportsCollector());
+    }
+
+    @Override
+    protected void doCollect() {}
+
+    private static class ThreadExportsCollector extends Collector {
+        private static ThreadExports threadExports = new ThreadExports();
+        @Override
+        public List<MetricFamilySamples> collect() {
+            List<MetricFamilySamples> collected = threadExports.collect();
+            List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+            
+            for(MetricFamilySamples mSample : collected) {
+                List<Sample> samples = new ArrayList<>(mSample.samples.size());
+                for(Sample sample : mSample.samples) {
+                    samples.add(new Sample(prefix(sample.name), sample.labelNames, sample.labelValues, sample.value));
+                }
+
+                MetricFamilySamples prefixed = new MetricFamilySamples(prefix(mSample.name), mSample.type, mSample.help, samples);
+                mfs.add(prefixed);
+            }
+            return mfs;
+        }
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/ThreadsWrapper.java
+++ b/src/main/java/de/sldk/mc/metrics/ThreadsWrapper.java
@@ -1,12 +1,10 @@
 package de.sldk.mc.metrics;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.plugin.Plugin;
 
 import io.prometheus.client.Collector;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.hotspot.ThreadExports;
 
 public class ThreadsWrapper extends Metric {
@@ -18,22 +16,11 @@ public class ThreadsWrapper extends Metric {
     protected void doCollect() {}
 
     private static class ThreadExportsCollector extends Collector {
-        private static ThreadExports threadExports = new ThreadExports();
+        private static final ThreadExports threadExports = new ThreadExports();
+
         @Override
         public List<MetricFamilySamples> collect() {
-            List<MetricFamilySamples> collected = threadExports.collect();
-            List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
-            
-            for(MetricFamilySamples mSample : collected) {
-                List<Sample> samples = new ArrayList<>(mSample.samples.size());
-                for(Sample sample : mSample.samples) {
-                    samples.add(new Sample(prefix(sample.name), sample.labelNames, sample.labelValues, sample.value));
-                }
-
-                MetricFamilySamples prefixed = new MetricFamilySamples(prefix(mSample.name), mSample.type, mSample.help, samples);
-                mfs.add(prefixed);
-            }
-            return mfs;
+            return HotspotPrefixer.prefixFromCollector(threadExports);
         }
     }
 }


### PR DESCRIPTION
Added 'Allocated' JVM memory label, same as is used in the F3 menu.
Added GC and Thread metrics from Hotspot prometheus package. Prefixing all metrics with `mc_`