### PR TITLE
Updated server dashboard to give correct Used memory

### DIFF
--- a/dashboards/minecraft-server-dashboard.json
+++ b/dashboards/minecraft-server-dashboard.json
@@ -509,7 +509,7 @@
           "step": 4
         },
         {
-          "expr": "mc_jvm_memory{type='max', server_name=~\"$server_name\"} - scalar(mc_jvm_memory{type='free', server_name=~\"$server_name\"})",
+          "expr": "mc_jvm_memory{type='allocated', server_name=~\"$server_name\"} - scalar(mc_jvm_memory{type='free', server_name=~\"$server_name\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,

--- a/dashboards/minecraft-server-dashboard.json
+++ b/dashboards/minecraft-server-dashboard.json
@@ -299,7 +299,7 @@
       "pluginVersion": "6.4.2",
       "targets": [
         {
-          "expr": "mc_jvm_memory{type='max', server_name=~\"$server_name\"} - scalar(mc_jvm_memory{type='free', server_name=~\"$server_name\"})",
+          "expr": "mc_jvm_memory{type='allocated', server_name=~\"$server_name\"} - scalar(mc_jvm_memory{type='free', server_name=~\"$server_name\"})",
           "instant": false,
           "refId": "A"
         }


### PR DESCRIPTION
'Used' memory should  naturally be <= 'Allocated' memory, not above: [source](https://stackoverflow.com/a/3571231)

New:
![image](https://user-images.githubusercontent.com/18282288/77345740-f97e1600-6d2c-11ea-8f72-57b3f249a225.png)

Old:
![image](https://user-images.githubusercontent.com/18282288/77345757-01d65100-6d2d-11ea-9d24-efc55f9bd25e.png)
