### PR TITLE
Add villager metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ mc_players_total | Unique players on server (online + offline)
 mc_loaded_chunks_total | Chunks loaded per world
 mc_players_online_total | Online players per world
 mc_entities_total | Entities loaded per world (living + non-living)
+mc_villagers_total | Villagers
 mc_jvm_memory | JVM memory usage
 mc_jvm_threads | JVM threads info
 mc_tps | Server tickrate (TPS)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.sldk.mc</groupId>
     <artifactId>minecraft-prometheus-exporter</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/de/sldk/mc/MetricsController.java
+++ b/src/main/java/de/sldk/mc/MetricsController.java
@@ -1,25 +1,16 @@
 package de.sldk.mc;
 
 import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Gauge;
 import io.prometheus.client.exporter.common.TextFormat;
-import org.bukkit.*;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 public class MetricsController extends AbstractHandler {
 

--- a/src/main/java/de/sldk/mc/PrometheusExporter.java
+++ b/src/main/java/de/sldk/mc/PrometheusExporter.java
@@ -1,7 +1,6 @@
 package de.sldk.mc;
 
 import de.sldk.mc.config.PrometheusExporterConfig;
-import de.sldk.mc.metrics.Metric;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jetty.server.Server;
 

--- a/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
+++ b/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
@@ -16,6 +16,7 @@ public class PrometheusExporterConfig {
     public static final PluginConfig<Integer> PORT = new PluginConfig<>("port", 9225);
     public static final List<MetricConfig> METRICS = Arrays.asList(
             metricConfig("entities_total", true, Entities::new),
+            metricConfig("villagers_total", true, Villagers::new),
             metricConfig("loaded_chunks_total", true, LoadedChunks::new),
             metricConfig("jvm_memory", true, Memory::new),
             metricConfig("players_online_total", true, PlayersOnlineTotal::new),

--- a/src/main/java/de/sldk/mc/metrics/Entities.java
+++ b/src/main/java/de/sldk/mc/metrics/Entities.java
@@ -44,23 +44,15 @@ public class Entities extends WorldMetric {
         Map<EntityType, Long> mapEntityTypesToCounts = world.getEntities().stream()
                 .collect(Collectors.groupingBy(Entity::getType, Collectors.counting()));
 
-        mapEntityTypesToCounts.keySet()
-                .forEach(entityType ->
+        mapEntityTypesToCounts
+                .forEach((entityType, count) ->
                         ENTITIES
                                 .labels(world.getName(),
                                         getEntityName(entityType),
                                         Boolean.toString(isEntityTypeAlive(entityType)),
                                         Boolean.toString(entityType.isSpawnable()))
-                                .set(mapEntityTypesToCounts.get(entityType))
+                                .set(count)
                 );
-    }
-
-    private String getEntityName(EntityType type) {
-        try {
-            return type.getKey().getKey();
-        } catch (IllegalArgumentException e) {
-            return type.name();
-        }
     }
 
     private boolean isEntityTypeAlive(EntityType type) {

--- a/src/main/java/de/sldk/mc/metrics/HotspotPrefixer.java
+++ b/src/main/java/de/sldk/mc/metrics/HotspotPrefixer.java
@@ -10,7 +10,7 @@ import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 public final class HotspotPrefixer {
     protected static List<MetricFamilySamples> prefixFromCollector(Collector collector) {
         List<MetricFamilySamples> collected = collector.collect();
-        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>();
+        List<MetricFamilySamples> mfs = new ArrayList<>();
 
         for (MetricFamilySamples mSample : collected) {
             List<Sample> samples = new ArrayList<>(mSample.samples.size());

--- a/src/main/java/de/sldk/mc/metrics/Tps.java
+++ b/src/main/java/de/sldk/mc/metrics/Tps.java
@@ -1,7 +1,6 @@
 package de.sldk.mc.metrics;
 
 import de.sldk.mc.tps.TpsCollector;
-import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;

--- a/src/main/java/de/sldk/mc/metrics/Villagers.java
+++ b/src/main/java/de/sldk/mc/metrics/Villagers.java
@@ -1,0 +1,80 @@
+package de.sldk.mc.metrics;
+
+import io.prometheus.client.Gauge;
+import org.bukkit.World;
+import org.bukkit.entity.Villager;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Get total count of Villagers.
+ * <p>
+ * Labelled by
+ * <ul>
+ *     <li> World ({@link World#getName()})
+ *     <li> Type, e.g. 'desert', 'plains ({@link org.bukkit.entity.Villager.Type})
+ *     <li> Profession, e.g. 'fisherman', 'farmer', or 'none' ({@link org.bukkit.entity.Villager.Profession})
+ *     <li> Level ({@link Villager#getVillagerLevel()})
+ * </ul>
+ */
+public class Villagers extends WorldMetric {
+
+    private static final Gauge VILLAGERS = Gauge.build()
+            .name(prefix("villagers_total"))
+            .help("Villagers total count, labelled by world, type, profession, and level")
+            .labelNames("world", "type", "profession", "level")
+            .create();
+
+    public Villagers(Plugin plugin) {
+        super(plugin, VILLAGERS);
+    }
+
+    @Override
+    public void collect(World world) {
+        Map<VillagerGrouping, Long> mapVillagerGroupingToCount = world
+                .getEntitiesByClass(Villager.class).stream()
+                .collect(Collectors.groupingBy(VillagerGrouping::new, Collectors.counting()));
+
+        mapVillagerGroupingToCount.forEach((grouping, count) ->
+                VILLAGERS
+                        .labels(world.getName(),
+                                grouping.type.getKey().getKey(),
+                                grouping.profession.getKey().getKey(),
+                                Integer.toString(grouping.level))
+                        .set(count)
+        );
+    }
+
+    /**
+     * Class used to group villagers together before summation.
+     */
+    private static class VillagerGrouping {
+        private final Villager.Type type;
+        private final Villager.Profession profession;
+        private final int level;
+
+        VillagerGrouping(Villager villager) {
+            this.type = villager.getVillagerType();
+            this.profession = villager.getProfession();
+            this.level = villager.getVillagerLevel();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            VillagerGrouping that = (VillagerGrouping) o;
+            return level == that.level &&
+                    type == that.type &&
+                    profession == that.profession;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, profession, level);
+        }
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/WorldMetric.java
+++ b/src/main/java/de/sldk/mc/metrics/WorldMetric.java
@@ -3,6 +3,7 @@ package de.sldk.mc.metrics;
 import io.prometheus.client.Collector;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.Plugin;
 
 public abstract class WorldMetric extends Metric {
@@ -20,4 +21,11 @@ public abstract class WorldMetric extends Metric {
 
     protected abstract void collect(World world);
 
+    protected String getEntityName(EntityType type) {
+        try {
+            return type.getKey().getKey();
+        } catch (IllegalArgumentException e) {
+            return type.name();
+        }
+    }
 }

--- a/src/main/test/de/sldk/mc/config/PrometheusExporterConfigTest.java
+++ b/src/main/test/de/sldk/mc/config/PrometheusExporterConfigTest.java
@@ -8,7 +8,7 @@ class PrometheusExporterConfigTest {
 
     @Test
     void test() {
-        Assertions.assertEquals(8, PrometheusExporterConfig.METRICS.size());
+        Assertions.assertEquals(9, PrometheusExporterConfig.METRICS.size());
     }
 
 }

--- a/src/main/test/de/sldk/mc/metrics/EntitiesTest.java
+++ b/src/main/test/de/sldk/mc/metrics/EntitiesTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 

--- a/src/main/test/de/sldk/mc/metrics/VillagersTest.java
+++ b/src/main/test/de/sldk/mc/metrics/VillagersTest.java
@@ -1,0 +1,91 @@
+package de.sldk.mc.metrics;
+
+import io.prometheus.client.CollectorRegistry;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Villager;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VillagersTest {
+
+    private static final String VILLAGERS_METRIC_NAME = "mc_villagers_total";
+    private static final String[] METRIC_LABELS = new String[]{"world", "type", "profession", "level"};
+
+    private Villagers villagersMetric;
+
+    @BeforeAll
+    static void beforeAllTests() {
+        CollectorRegistry.defaultRegistry.clear();
+    }
+
+    @BeforeEach
+    void beforeEachTest() {
+        villagersMetric = new Villagers(mock(Plugin.class));
+        villagersMetric.enable();
+    }
+
+    @AfterEach
+    void afterEachTest() {
+        CollectorRegistry.defaultRegistry.clear();
+    }
+
+    @Test
+    void givenVillagersExpectCorrectCount() {
+        final String worldName = "world_name";
+        final long numOfDesertFarmersLevel1 = 2;
+        final long numOfPlainsNoneLevel2 = 3;
+
+        List<Entity> mockedVillagers = new ArrayList<>();
+        mockedVillagers.addAll(mockVillagers(numOfDesertFarmersLevel1, Villager.Type.DESERT, Villager.Profession.FARMER, 1));
+        mockedVillagers.addAll(mockVillagers(numOfPlainsNoneLevel2, Villager.Type.PLAINS, Villager.Profession.NONE, 2));
+        Collections.shuffle(mockedVillagers);
+
+        World world = mock(World.class);
+        when(world.getName()).thenReturn(worldName);
+        when(world.getEntities()).thenReturn(mockedVillagers);
+
+        villagersMetric.collect(world);
+
+        assertEquals(numOfDesertFarmersLevel1,
+                CollectorRegistry.defaultRegistry
+                        .getSampleValue(VILLAGERS_METRIC_NAME,
+                                METRIC_LABELS,
+                                new String[]{worldName, "desert", "farmer", "1"}));
+
+        assertEquals(numOfPlainsNoneLevel2,
+                CollectorRegistry.defaultRegistry
+                        .getSampleValue(VILLAGERS_METRIC_NAME,
+                                METRIC_LABELS,
+                                new String[]{worldName, "plains", "none", "2"}));
+    }
+
+    private List<Entity> mockVillagers(long count, Villager.Type type, Villager.Profession profession, int level) {
+        return LongStream.range(0, count)
+                .mapToObj(i -> mockVillager(type, profession, level))
+                .collect(Collectors.toList());
+    }
+
+    private Entity mockVillager(Villager.Type type, Villager.Profession profession, int level) {
+        Villager e = mock(Villager.class);
+        when(e.getType()).thenReturn(EntityType.VILLAGER);
+        when(e.getVillagerType()).thenReturn(type);
+        when(e.getProfession()).thenReturn(profession);
+        when(e.getVillagerLevel()).thenReturn(level);
+        return e;
+    }
+}


### PR DESCRIPTION
I've added a metric to count how many villagers there are. These are labelled by world type (desert, plains, etc), profession, and level.

I'm not sure what the performance impact of having 4 labels could be - do you think it will be okay? I think the 'level' label could be removed at the least.

README has been updated, unit tests added/updated, and I've bumped the version number.

I also tidied up the code a bit (unused imports, that sort of thing).

Grafana stacked graph:

![image](https://user-images.githubusercontent.com/897017/77810381-79411300-7094-11ea-81cc-a627c4bedf9d.png)

