### PR TITLE
Add tick duration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Here's a default config with annotations.
 
 ```yml
 # Note that the HTTP server binds to localhost by default.
-# If your Prometheus runs on another host or inside a Kubernetes cluster 
+# If your Prometheus runs on another host or inside a Kubernetes cluster
 # set this to any reachable IP or 0.0.0.0 to listen on all interfaces.
 host: localhost
 # The port can be changed in case it conflicts with any other application.
 port: 9225
-# Metrics can be enabled individually. Metrics which are disabled 
-# by default may have a performance impact on your server. 
+# Metrics can be enabled individually. Metrics which are disabled
+# by default may have a performance impact on your server.
 # See the rest of the README for more information.
 enable_metrics:
   jvm_threads: true
@@ -42,6 +42,10 @@ enable_metrics:
   jvm_memory: true
   players_online_total: true
   tps: true
+  tick_duration_average: true
+  tick_duration_median: true
+  tick_duration_min: false
+  tick_duration_max: true
   player_online: false
   player_statistic: false
 ```
@@ -96,13 +100,17 @@ mc_villagers_total | Villagers
 mc_jvm_memory | JVM memory usage
 mc_jvm_threads | JVM threads info
 mc_tps | Server tickrate (TPS)
+mc_tick_duration_median | Median Tick Duration (ns, usually last 100 ticks)
+mc_tick_duration_average | Average Tick Duration (ns, usually last 100 ticks)
+mc_tick_duration_min | Min Tick Duration (ns, usually last 100 ticks)
+mc_tick_duration_max | Max Tick Duration (ns, usually last 100 ticks)
 
 ## Player metrics (experimental!)
 
 :warning: **The following feature is against Prometheus best-practices and is not recommended for production servers!**
 
-There is an option to export per-player statistics like the number of blocks mined, mobs killed, items used, etc. 
-The amount of data stored in Prometheus can dramatically increase when this is enabled as individual time-series 
+There is an option to export per-player statistics like the number of blocks mined, mobs killed, items used, etc.
+The amount of data stored in Prometheus can dramatically increase when this is enabled as individual time-series
 will be generated for each player that has ever been seen on the server. The statistic collection may also have an
 impact on the Minecraft server performance for bigger servers but it has not been measured or tested.
 
@@ -123,7 +131,7 @@ Label | Description
 mc_player_statistic | Player statistics
 mc_player_online | Online state by player name
 
-There's a sample [dashboard](https://raw.githubusercontent.com/sladkoff/minecraft-prometheus-exporter/master/dashboards/minecraft-players-dashboard.json) 
+There's a sample [dashboard](https://raw.githubusercontent.com/sladkoff/minecraft-prometheus-exporter/master/dashboards/minecraft-players-dashboard.json)
 available to get you started.
 
 ## Collect metrics about your own plugin
@@ -157,7 +165,7 @@ public class MyPluginCommand extends PluginCommand {
   public boolean execute​(CommandSender sender, String commandLabel, String[] args) {
 
     // Increment your counter;
-    commandCounter.inc(); 
+    commandCounter.inc();
 
     // Do other stuff
 

--- a/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
+++ b/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
@@ -26,6 +26,11 @@ public class PrometheusExporterConfig {
             metricConfig("jvm_threads", true, ThreadsWrapper::new),
             metricConfig("jvm_gc", true, GarbageCollectorWrapper::new),
 
+            metricConfig("tick_duration_median", true, TickDurationMedianCollector::new),
+            metricConfig("tick_duration_average", true, TickDurationAverageCollector::new),
+            metricConfig("tick_duration_min", false, TickDurationMinCollector::new),
+            metricConfig("tick_duration_max", true, TickDurationMaxCollector::new),
+
             metricConfig("player_online", false, PlayerOnline::new),
             metricConfig("player_statistic", false, PlayerStatistics::new));
 

--- a/src/main/java/de/sldk/mc/metrics/TickDurationAverageCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationAverageCollector.java
@@ -1,0 +1,35 @@
+package de.sldk.mc.metrics;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Gauge;
+
+public class TickDurationAverageCollector extends TickDurationCollector {
+    private static final String NAME = "tick_duration_average";
+
+    private static final Gauge TD = Gauge.build()
+            .name(prefix(NAME))
+            .help("Average duration of server tick (nanoseconds)")
+            .create();
+
+    public TickDurationAverageCollector(Plugin plugin) {
+        super(plugin, TD, NAME);
+    }
+
+    private long getTickDurationAverage() {
+        if (getTickDurations() != null) {
+            long sum = 0;
+            long[] durations = getTickDurations();
+            for (Long val : durations) {
+                sum += val;
+            }
+            return sum / durations.length;
+        }
+        return 0;
+    }
+
+    @Override
+    public void doCollect() {
+        TD.set(getTickDurationAverage());
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/TickDurationAverageCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationAverageCollector.java
@@ -17,15 +17,12 @@ public class TickDurationAverageCollector extends TickDurationCollector {
     }
 
     private long getTickDurationAverage() {
-        if (getTickDurations() != null) {
-            long sum = 0;
-            long[] durations = getTickDurations();
-            for (Long val : durations) {
-                sum += val;
-            }
-            return sum / durations.length;
+        long sum = 0;
+        long[] durations = getTickDurations();
+        for (Long val : durations) {
+            sum += val;
         }
-        return 0;
+        return sum / durations.length;
     }
 
     @Override

--- a/src/main/java/de/sldk/mc/metrics/TickDurationCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationCollector.java
@@ -1,0 +1,54 @@
+package de.sldk.mc.metrics;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Gauge;
+
+public abstract class TickDurationCollector extends Metric {
+    /*
+     * If reflection is successful, this will hold a reference directly to the
+     * MinecraftServer internal tick duration tracker
+     */
+    private static long[] tickDurationReference = null;
+
+    public TickDurationCollector(Plugin plugin, Gauge gauge, String name) {
+        super(plugin, gauge);
+
+        /*
+         * If there is not yet a handle to the internal tick duration buffer, try
+         * to acquire one using reflection.
+         *
+         * This searches for any long[] array in the MinecraftServer class. It should
+         * work across many versions of Spigot/Paper and various obfuscation mappings
+         */
+        if (tickDurationReference == null) {
+            try {
+                /* Get the actual minecraft server class */
+                Server server = Bukkit.getServer();
+                Method getServerMethod = server.getClass().getMethod("getServer");
+                Object minecraftServer = getServerMethod.invoke(server);
+
+                /* Look for the only array of longs in that class, which is tick duration */
+                for (Field field : minecraftServer.getClass().getSuperclass().getDeclaredFields()) {
+                    if (field.getType().isArray() && field.getType().getComponentType().equals(long.class)) {
+                        tickDurationReference = (long[]) field.get(minecraftServer);
+                        return;
+                    }
+                }
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.FINE, "Caught exception looking for tick times array: ", e);
+            }
+            plugin.getLogger().log(Level.WARNING, "Failed to find tick times buffer via reflection; " + name + " data not available");
+        }
+    }
+
+    protected static long[] getTickDurations() {
+        return tickDurationReference;
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/TickDurationCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationCollector.java
@@ -41,7 +41,7 @@ public abstract class TickDurationCollector extends Metric {
                     if (field.getType().isArray() && field.getType().getComponentType().equals(long.class)) {
                         /* Check all the long[] items in this class, and remember the one with the most elements */
                         long[] array = (long[]) field.get(minecraftServer);
-                        if (longestArray == null || array.length > longestArray.length) {
+                        if (array != null && (longestArray == null || array.length > longestArray.length)) {
                             longestArray = array;
                         }
                     }

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMaxCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMaxCollector.java
@@ -17,16 +17,13 @@ public class TickDurationMaxCollector extends TickDurationCollector {
     }
 
     private long getTickDurationMax() {
-        if (getTickDurations() != null) {
-            long max = Long.MIN_VALUE;
-            for (Long val : getTickDurations()) {
-                if (val > max) {
-                    max = val;
-                }
+        long max = Long.MIN_VALUE;
+        for (Long val : getTickDurations()) {
+            if (val > max) {
+                max = val;
             }
-            return max;
         }
-        return 0;
+        return max;
     }
 
     @Override

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMaxCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMaxCollector.java
@@ -1,0 +1,37 @@
+package de.sldk.mc.metrics;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Gauge;
+
+public class TickDurationMaxCollector extends TickDurationCollector {
+    private static final String NAME = "tick_duration_max";
+
+    private static final Gauge TD = Gauge.build()
+            .name(prefix(NAME))
+            .help("Max duration of server tick (nanoseconds)")
+            .create();
+
+    public TickDurationMaxCollector(Plugin plugin) {
+        super(plugin, TD, NAME);
+    }
+
+    private long getTickDurationMax() {
+        if (getTickDurations() != null) {
+            long max = Long.MIN_VALUE;
+            for (Long val : getTickDurations()) {
+                if (val > max) {
+                    max = val;
+                }
+            }
+            return max;
+        }
+        return 0;
+    }
+
+    @Override
+    public void doCollect() {
+        TD.set(getTickDurationMax());
+    }
+}
+

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMedianCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMedianCollector.java
@@ -1,0 +1,37 @@
+package de.sldk.mc.metrics;
+
+import java.util.Arrays;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Gauge;
+
+public class TickDurationMedianCollector extends TickDurationCollector {
+    private static final String NAME = "tick_duration_median";
+
+    private static final Gauge TD = Gauge.build()
+            .name(prefix(NAME))
+            .help("Median duration of server tick (nanoseconds)")
+            .create();
+
+    public TickDurationMedianCollector(Plugin plugin) {
+        super(plugin, TD, NAME);
+    }
+
+    private long getTickDurationMedian() {
+        if (getTickDurations() != null) {
+            /* Copy the original array - don't want to sort it! */
+            long[] tickTimes = getTickDurations().clone();
+            if (tickTimes.length > 0) {
+                Arrays.sort(tickTimes);
+                return tickTimes[tickTimes.length / 2];
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public void doCollect() {
+        TD.set(getTickDurationMedian());
+    }
+}

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMedianCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMedianCollector.java
@@ -19,15 +19,10 @@ public class TickDurationMedianCollector extends TickDurationCollector {
     }
 
     private long getTickDurationMedian() {
-        if (getTickDurations() != null) {
-            /* Copy the original array - don't want to sort it! */
-            long[] tickTimes = getTickDurations().clone();
-            if (tickTimes.length > 0) {
-                Arrays.sort(tickTimes);
-                return tickTimes[tickTimes.length / 2];
-            }
-        }
-        return 0;
+        /* Copy the original array - don't want to sort it! */
+        long[] tickTimes = getTickDurations().clone();
+        Arrays.sort(tickTimes);
+        return tickTimes[tickTimes.length / 2];
     }
 
     @Override

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMinCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMinCollector.java
@@ -1,0 +1,37 @@
+package de.sldk.mc.metrics;
+
+import org.bukkit.plugin.Plugin;
+
+import io.prometheus.client.Gauge;
+
+public class TickDurationMinCollector extends TickDurationCollector {
+    private static final String NAME = "tick_duration_min";
+
+    private static final Gauge TD = Gauge.build()
+            .name(prefix(NAME))
+            .help("Min duration of server tick (nanoseconds)")
+            .create();
+
+    public TickDurationMinCollector(Plugin plugin) {
+        super(plugin, TD, NAME);
+    }
+
+    private long getTickDurationMin() {
+        if (getTickDurations() != null) {
+            long min = Long.MAX_VALUE;
+            for (Long val : getTickDurations()) {
+                if (val < min) {
+                    min = val;
+                }
+            }
+            return min;
+        }
+        return 0;
+    }
+
+    @Override
+    public void doCollect() {
+        TD.set(getTickDurationMin());
+    }
+}
+

--- a/src/main/java/de/sldk/mc/metrics/TickDurationMinCollector.java
+++ b/src/main/java/de/sldk/mc/metrics/TickDurationMinCollector.java
@@ -17,16 +17,13 @@ public class TickDurationMinCollector extends TickDurationCollector {
     }
 
     private long getTickDurationMin() {
-        if (getTickDurations() != null) {
-            long min = Long.MAX_VALUE;
-            for (Long val : getTickDurations()) {
-                if (val < min) {
-                    min = val;
-                }
+        long min = Long.MAX_VALUE;
+        for (Long val : getTickDurations()) {
+            if (val < min) {
+                min = val;
             }
-            return min;
         }
-        return 0;
+        return min;
     }
 
     @Override


### PR DESCRIPTION
This adds the metrics: 
tick_duration_median
tick_duration_max
tick_duration_min

Rather than just return the most recent tick duration, I thought these metrics would be a bit more useful. Minimum is sort of useless... Might want to make it off by default?

These use reflection to find the internal tick duration buffer of the minecraft server, and then use that for metrics. Will likely work on many spigot server versions, but is probably not future proof.

Implements #39. Improvements/suggestions welcome. The recommended dashboard likely needs to have this added too, but this patch does not handle that. 