### PR TITLE
add gzip transport support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <bukkit.version>1.15.1-R0.1-SNAPSHOT</bukkit.version>
-        <jetty.version>9.4.25.v20191220</jetty.version>
+        <jetty.version>9.4.28.v20200408</jetty.version>
         <prometheus-client.version>0.8.1</prometheus-client.version>
         <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <org.mockito.version>3.3.3</org.mockito.version>

--- a/src/main/java/de/sldk/mc/PrometheusExporter.java
+++ b/src/main/java/de/sldk/mc/PrometheusExporter.java
@@ -3,6 +3,7 @@ package de.sldk.mc;
 import de.sldk.mc.config.PrometheusExporterConfig;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 
 import java.net.InetSocketAddress;
 import java.util.logging.Level;
@@ -26,9 +27,12 @@ public class PrometheusExporter extends JavaPlugin {
         int port = config.get(PrometheusExporterConfig.PORT);
         String host = config.get(PrometheusExporterConfig.HOST);
 
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.setHandler(new MetricsController(this));
+
         InetSocketAddress address = new InetSocketAddress(host, port);
         server = new Server(address);
-        server.setHandler(new MetricsController(this));
+        server.setHandler(gzipHandler);
 
         try {
             server.start();


### PR DESCRIPTION
Adds support for gzip transport encoding.
I've added some of my own custom metrics (in a different plugin), which have beefed up the payload size to where compression makes a significant difference. In my use case, this reduces payload size by about 86%.

Edit:
The Jetty upgrade is to address eclipse/jetty.project#4461