### PR TITLE
Clear all the metrics in the existing gauge in the entities and villager counters before collection

### DIFF
--- a/src/main/java/de/sldk/mc/metrics/Entities.java
+++ b/src/main/java/de/sldk/mc/metrics/Entities.java
@@ -40,6 +40,11 @@ public class Entities extends WorldMetric {
     }
 
     @Override
+    protected void clear() {
+        ENTITIES.clear();
+    }
+
+    @Override
     public void collect(World world) {
         Map<EntityType, Long> mapEntityTypesToCounts = world.getEntities().stream()
                 .collect(Collectors.groupingBy(Entity::getType, Collectors.counting()));

--- a/src/main/java/de/sldk/mc/metrics/LoadedChunks.java
+++ b/src/main/java/de/sldk/mc/metrics/LoadedChunks.java
@@ -17,6 +17,10 @@ public class LoadedChunks extends WorldMetric {
     }
 
     @Override
+    protected void clear() {
+    }
+
+    @Override
     public void collect(World world) {
         LOADED_CHUNKS.labels(world.getName()).set(world.getLoadedChunks().length);
     }

--- a/src/main/java/de/sldk/mc/metrics/PlayersOnlineTotal.java
+++ b/src/main/java/de/sldk/mc/metrics/PlayersOnlineTotal.java
@@ -17,6 +17,10 @@ public class PlayersOnlineTotal extends WorldMetric {
     }
 
     @Override
+    protected void clear() {
+    }
+
+    @Override
     protected void collect(World world) {
         PLAYERS_ONLINE.labels(world.getName()).set(world.getPlayers().size());
     }

--- a/src/main/java/de/sldk/mc/metrics/Villagers.java
+++ b/src/main/java/de/sldk/mc/metrics/Villagers.java
@@ -33,6 +33,11 @@ public class Villagers extends WorldMetric {
     }
 
     @Override
+    protected void clear() {
+        VILLAGERS.clear();
+    }
+
+    @Override
     public void collect(World world) {
         Map<VillagerGrouping, Long> mapVillagerGroupingToCount = world
                 .getEntitiesByClass(Villager.class).stream()

--- a/src/main/java/de/sldk/mc/metrics/WorldMetric.java
+++ b/src/main/java/de/sldk/mc/metrics/WorldMetric.java
@@ -14,11 +14,13 @@ public abstract class WorldMetric extends Metric {
 
     @Override
     public final void doCollect() {
+        clear();
         for (World world : Bukkit.getWorlds()) {
             collect(world);
         }
     }
 
+    protected abstract void clear();
     protected abstract void collect(World world);
 
     protected String getEntityName(EntityType type) {


### PR DESCRIPTION
This essentially fixes #46. I too noticed that if a certain type of entity would be completely unloaded, it would remain on the last value. This is easy to test by flying to a new ocean monument ingame. 3 elder guardians would show up. Afterwards when flying away from it to the point where the chunks would be unloaded, it would still shows as 3 elder guardians being loaded even if nobody would be even near an ocean. After I tried the same thing with this patch I correctly saw entities disappear from the metrics as you'd expect.