### PR TITLE
Add api-version to prevent legacy material support initialization

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,4 @@ version: 2.3.0-SNAPSHOT
 author: sldk
 main: de.sldk.mc.PrometheusExporter
 website: sldk.de
+api-version: 1.13


### PR DESCRIPTION
Without an `api-version` in the plugin.yml, servers running this plugin will be forced to initialize legacy material support on startup. The issue with this is that the Material enum is nearly doubled in size, which has performance impacts on the server.