### PR TITLE
Add bungeecord plugin direct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 A **Bukkit plugin** which exports Minecraft server stats for Prometheus.
 
+Looking for prometheus-export for a network? Try [Bungeecord Prometheus Exporter](https://github.com/weihao/bungeecord-prometheus-exporter)!
+
 ## Quick Start
 
 Drop the prometheus-exporter.jar into your Bukkit plugins directory and start your Minecraft server.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A **Bukkit plugin** which exports Minecraft server stats for Prometheus.
 
-Looking for prometheus-export for a network? Try [Bungeecord Prometheus Exporter](https://github.com/weihao/bungeecord-prometheus-exporter)!
+If you're running multiple Minecraft servers behind a BungeeCord proxy, you might also be interested in [Bungeecord Prometheus Exporter](https://github.com/weihao/bungeecord-prometheus-exporter) for additional metrics!
 
 ## Quick Start
 


### PR DESCRIPTION
I am working on a Prometheus exporter for bungeecord, started on abstracting the repo and refactor your implementation into PrometheusSpigotExporter and write my own PrometheusBungeeExporter.

unfortunately, it did not work out and abstraction was not ideal since Bungeecord and Spigot Plugins are very different, so I decided to make a separate plugin.