### PR TITLE
#94: Don't log flood logs with stacktraces

### DIFF
--- a/src/main/java/de/sldk/mc/metrics/player/PlayerStatisticLoaderFromBukkit.java
+++ b/src/main/java/de/sldk/mc/metrics/player/PlayerStatisticLoaderFromBukkit.java
@@ -84,7 +84,8 @@ public class PlayerStatisticLoaderFromBukkit implements PlayerStatisticLoader {
                 return 0;
             }
         } catch (Exception e) {
-            logger.log(Level.WARNING, "Exception fetching statistic " + statistic + " from player", e);
+            logger.warning(String.format("Exception fetching statistic %s (type=%s) for player", statistic, statType));
+            logger.throwing(getClass().getSimpleName(), "getTypedStatistic", e);
             return 0;
         }
     }


### PR DESCRIPTION
When a typed statistic can not be loaded, log the statistic and type on WARN to allow debugging, but don't dump the stacktrace.