### PR TITLE
#94: Don't flood logs with stacktraces (2)

### DIFF
--- a/src/main/java/de/sldk/mc/metrics/player/PlayerStatisticLoaderFromBukkit.java
+++ b/src/main/java/de/sldk/mc/metrics/player/PlayerStatisticLoaderFromBukkit.java
@@ -59,7 +59,8 @@ public class PlayerStatisticLoaderFromBukkit implements PlayerStatisticLoader {
         try {
             return player.getStatistic(statistic);
         } catch (IllegalArgumentException e) {
-            logger.log(Level.WARNING, "Exception fetching statistic " + statistic + " from player", e);
+            logger.warning(String.format("Exception fetching statistic %s for player", statistic));
+            logger.throwing(getClass().getSimpleName(), "getUntypedStatistic", e);
             return 0;
         }
     }


### PR DESCRIPTION
When a typed statistic can not be loaded, log the statistic and type on WARN to allow debugging, but don't dump the stacktrace.