### PR TITLE
Add support for health-checking

### DIFF
--- a/src/main/java/de/sldk/mc/HealthController.java
+++ b/src/main/java/de/sldk/mc/HealthController.java
@@ -1,0 +1,33 @@
+package de.sldk.mc;
+
+import de.sldk.mc.health.HealthChecks;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class HealthController extends AbstractHandler {
+
+    private final HealthChecks checks;
+
+    private HealthController(final HealthChecks checks) {
+        this.checks = checks;
+    }
+
+    public static Handler create(final HealthChecks checks) {
+        return new HealthController(checks);
+    }
+
+    @Override
+    public void handle(final String target,
+                       final Request baseRequest,
+                       final HttpServletRequest request,
+                       final HttpServletResponse response) {
+        if (!target.equals("/health")) return;
+
+        response.setStatus(checks.isHealthy() ? HttpStatus.OK_200 : HttpStatus.SERVICE_UNAVAILABLE_503);
+        baseRequest.setHandled(true);
+    }
+}

--- a/src/main/java/de/sldk/mc/MetricsController.java
+++ b/src/main/java/de/sldk/mc/MetricsController.java
@@ -5,6 +5,7 @@ import io.prometheus.client.exporter.common.TextFormat;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 
@@ -18,18 +19,20 @@ public class MetricsController extends AbstractHandler {
     private final MetricRegistry metricRegistry = MetricRegistry.getInstance();
     private final PrometheusExporter exporter;
 
-    public MetricsController(PrometheusExporter exporter) {
+    private MetricsController(PrometheusExporter exporter) {
         this.exporter = exporter;
     }
 
-    @Override
-    public void handle(String target, Request request, HttpServletRequest httpServletRequest,
-            HttpServletResponse response) throws IOException {
+    public static Handler create(final PrometheusExporter exporter) {
+        return new MetricsController(exporter);
+    }
 
-        if (!target.equals("/metrics")) {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
+    @Override
+    public void handle(final String target,
+                       final Request request,
+                       final HttpServletRequest httpServletRequest,
+                       final HttpServletResponse response) throws IOException{
+        if (!target.equals("/metrics")) return;
 
         /*
          * Bukkit API calls have to be made from the main thread.

--- a/src/main/java/de/sldk/mc/MetricsServer.java
+++ b/src/main/java/de/sldk/mc/MetricsServer.java
@@ -1,6 +1,8 @@
 package de.sldk.mc;
 
+import de.sldk.mc.health.HealthChecks;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 
 import java.net.InetSocketAddress;
@@ -10,18 +12,23 @@ public class MetricsServer {
 	private final String host;
 	private final int port;
 	private final PrometheusExporter prometheusExporter;
+	private final HealthChecks healthChecks;
 
 	private Server server;
 
-	public MetricsServer(String host, int port, PrometheusExporter prometheusExporter) {
+	public MetricsServer(String host, int port, PrometheusExporter prometheusExporter, HealthChecks healthChecks) {
 		this.host = host;
 		this.port = port;
 		this.prometheusExporter = prometheusExporter;
+		this.healthChecks = healthChecks;
 	}
 
 	public void start() throws Exception {
 		GzipHandler gzipHandler = new GzipHandler();
-		gzipHandler.setHandler(new MetricsController(prometheusExporter));
+		gzipHandler.setHandler(new HandlerList(
+				MetricsController.create(prometheusExporter),
+				HealthController.create(healthChecks)
+		));
 
 		InetSocketAddress address = new InetSocketAddress(host, port);
 		server = new Server(address);

--- a/src/main/java/de/sldk/mc/MetricsServer.java
+++ b/src/main/java/de/sldk/mc/MetricsServer.java
@@ -24,15 +24,15 @@ public class MetricsServer {
 	}
 
 	public void start() throws Exception {
-		GzipHandler gzipHandler = new GzipHandler();
-		gzipHandler.setHandler(new HandlerList(
-				MetricsController.create(prometheusExporter),
-				HealthController.create(healthChecks)
-		));
+		GzipHandler metricsHandler = new GzipHandler();
+		metricsHandler.setHandler(MetricsController.create(prometheusExporter));
 
 		InetSocketAddress address = new InetSocketAddress(host, port);
 		server = new Server(address);
-		server.setHandler(gzipHandler);
+		server.setHandler(new HandlerList(
+				metricsHandler,
+				HealthController.create(healthChecks)
+		));
 
 		server.start();
 	}

--- a/src/main/java/de/sldk/mc/PrometheusExporter.java
+++ b/src/main/java/de/sldk/mc/PrometheusExporter.java
@@ -1,6 +1,9 @@
 package de.sldk.mc;
 
 import de.sldk.mc.config.PrometheusExporterConfig;
+import de.sldk.mc.health.ConcurrentHealthChecks;
+import de.sldk.mc.health.HealthChecks;
+import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.logging.Level;
@@ -17,14 +20,17 @@ public class PrometheusExporter extends JavaPlugin {
 
         config.enableConfiguredMetrics();
 
-        startMetricsServer();
+        HealthChecks healthChecks = ConcurrentHealthChecks.create();
+        getServer().getServicesManager().register(HealthChecks.class, healthChecks, this, ServicePriority.Normal);
+
+        startMetricsServer(healthChecks);
     }
 
-    private void startMetricsServer() {
+    private void startMetricsServer(HealthChecks healthChecks) {
         String host = config.get(PrometheusExporterConfig.HOST);
         Integer port = config.get(PrometheusExporterConfig.PORT);
 
-		server = new MetricsServer(host, port, this);
+		server = new MetricsServer(host, port, this, healthChecks);
 
         try {
             server.start();

--- a/src/main/java/de/sldk/mc/health/ConcurrentHealthChecks.java
+++ b/src/main/java/de/sldk/mc/health/ConcurrentHealthChecks.java
@@ -1,0 +1,33 @@
+package de.sldk.mc.health;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ConcurrentHealthChecks implements HealthChecks {
+
+    private final Set<HealthCheck> checks;
+
+    private ConcurrentHealthChecks(final Set<HealthCheck> checks) {
+        this.checks = checks;
+    }
+
+    public static HealthChecks create() {
+        return new ConcurrentHealthChecks(ConcurrentHashMap.newKeySet());
+    }
+
+    @Override
+    public boolean isHealthy() {
+        for (final HealthCheck check : checks) if (!check.isHealthy()) return false;
+        return true;
+    }
+
+    @Override
+    public void add(final HealthCheck check) {
+        checks.add(check);
+    }
+
+    @Override
+    public void remove(final HealthCheck check) {
+        checks.remove(check);
+    }
+}

--- a/src/main/java/de/sldk/mc/health/HealthCheck.java
+++ b/src/main/java/de/sldk/mc/health/HealthCheck.java
@@ -1,0 +1,64 @@
+package de.sldk.mc.health;
+
+/**
+ * Health check.
+ */
+public interface HealthCheck {
+
+    /**
+     * Checks if the current state is healthy.
+     *
+     * @return {@code true} if the state is healthy and {@code false} otherwise
+     */
+    boolean isHealthy();
+
+    /**
+     * Creates a health compound check from the provided ones reporting healthy status iff all the checks report it.
+     *
+     * @param healthChecks merged health checks
+     * @return compound health check
+     */
+    static HealthCheck allOf(final HealthCheck... healthChecks) {
+        return new AllOf(healthChecks);
+    }
+
+    /**
+     * Creates a compound health check from the provided ones reporting healthy status iff any check reports it.
+     *
+     * @param healthChecks merged health checks
+     * @return compound health check
+     */
+    static HealthCheck anyOf(final HealthCheck... healthChecks) {
+        return new AnyOf(healthChecks);
+    }
+
+    final class AllOf implements HealthCheck {
+        private final HealthCheck[] checks;
+
+        private AllOf(final HealthCheck[] checks) {
+            this.checks = checks;
+        }
+
+        @Override
+        public boolean isHealthy() {
+            for (final HealthCheck check : checks) if (!check.isHealthy()) return false;
+
+            return true;
+        }
+    }
+
+    final class AnyOf implements HealthCheck {
+        private final HealthCheck[] checks;
+
+        private AnyOf(final HealthCheck[] checks) {
+            this.checks = checks;
+        }
+
+        @Override
+        public boolean isHealthy() {
+            for (final HealthCheck check : checks) if (check.isHealthy()) return true;
+
+            return false;
+        }
+    }
+}

--- a/src/main/java/de/sldk/mc/health/HealthCheck.java
+++ b/src/main/java/de/sldk/mc/health/HealthCheck.java
@@ -15,21 +15,21 @@ public interface HealthCheck {
     /**
      * Creates a health compound check from the provided ones reporting healthy status iff all the checks report it.
      *
-     * @param healthChecks merged health checks
+     * @param checks merged health checks
      * @return compound health check
      */
-    static HealthCheck allOf(final HealthCheck... healthChecks) {
-        return new AllOf(healthChecks);
+    static HealthCheck allOf(final HealthCheck... checks) {
+        return new AllOf(checks);
     }
 
     /**
      * Creates a compound health check from the provided ones reporting healthy status iff any check reports it.
      *
-     * @param healthChecks merged health checks
+     * @param checks merged health checks
      * @return compound health check
      */
-    static HealthCheck anyOf(final HealthCheck... healthChecks) {
-        return new AnyOf(healthChecks);
+    static HealthCheck anyOf(final HealthCheck... checks) {
+        return new AnyOf(checks);
     }
 
     final class AllOf implements HealthCheck {

--- a/src/main/java/de/sldk/mc/health/HealthChecks.java
+++ b/src/main/java/de/sldk/mc/health/HealthChecks.java
@@ -1,0 +1,21 @@
+package de.sldk.mc.health;
+
+/**
+ * Dynamic compound health checks.
+ */
+public interface HealthChecks extends HealthCheck {
+
+    /**
+     * Adds the provided health check to this one.
+     *
+     * @param check added health check
+     */
+    void add(HealthCheck check);
+
+    /**
+     * Removes the provided health check from this one.
+     *
+     * @param check removed health check
+     */
+    void remove(HealthCheck check);
+}

--- a/src/test/java/de/sldk/mc/exporter/PrometheusExporterTest.java
+++ b/src/test/java/de/sldk/mc/exporter/PrometheusExporterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import de.sldk.mc.MetricsServer;
 import de.sldk.mc.PrometheusExporter;
+import de.sldk.mc.health.ConcurrentHealthChecks;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -43,7 +44,9 @@ public class PrometheusExporterTest {
 	void setup() throws Exception {
 		CollectorRegistry.defaultRegistry.clear();
 		metricsServerPort = getRandomFreePort();
-		metricsServer = new MetricsServer("localhost", metricsServerPort, exporterMock);
+		metricsServer = new MetricsServer(
+                "localhost", metricsServerPort, exporterMock, ConcurrentHealthChecks.create()
+        );
 		metricsServer.start();
 	}
 


### PR DESCRIPTION
# Description

Kubernetes-backed servers may want to report their current status via a health check which may rely on implementation-specific details (such as servers exposing their internal connectivity info).

In order to implement this behaviour as part of this plugin:
- `HealthCheck` and `HealthChecks` interfaces were added to facilitate the creation of such health checks
- `HealthChecks` became registered as a Bukkit service so that other plugins can modify it
- an extra endpoint `/health` was added in order to response with 2xx (i.e. 200) code when the checks return healthy status and 4xx (i.e. 403) otherwise

# Affected code

Among the changes, the creation of `MetricsController` was abstracted into a static factory.

# Notes

- Default Jetty handler is now used for handling incorrect endpoint.

- It may be reasonable to make exact endpoints used configurable but it is not part of this PR (as this was not configurable before).
