### PR TITLE
Reset world chunks metric to fix accumulating unloaded worlds

### DIFF
--- a/src/main/java/de/sldk/mc/metrics/LoadedChunks.java
+++ b/src/main/java/de/sldk/mc/metrics/LoadedChunks.java
@@ -18,6 +18,7 @@ public class LoadedChunks extends WorldMetric {
 
     @Override
     protected void clear() {
+		LOADED_CHUNKS.clear();
     }
 
     @Override


### PR DESCRIPTION
Currently without this clear() the prometheus exporter continues to send the results for worlds that have unloaded, resulting in the appearance of potentially hundreds of loaded worlds even if only a few are currently actually in use. 