### PR TITLE
fix: Plugin crashes on Azul JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2024-01-02
+
+Special thanks to all new and old contributors :star:
+
+### Fixed
+- [#197](https://github.com/sladkoff/minecraft-prometheus-exporter/issues/197): Plugin crashes on Azul JVM
+
+
 ## [v2.5.0] - 2022-04-11
 
 Special thanks to all new and old contributors :star:

--- a/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
+++ b/src/main/java/de/sldk/mc/config/PrometheusExporterConfig.java
@@ -61,16 +61,22 @@ public class PrometheusExporterConfig {
     public void enableConfiguredMetrics() {
         PrometheusExporterConfig.METRICS
                 .forEach(metricConfig -> {
-                    Metric metric = metricConfig.getMetric(prometheusExporter);
-                    Boolean enabled = get(metricConfig);
+                    String metricName = metricConfig.getClass().getSimpleName();
+                    try {
+                        Metric metric = metricConfig.getMetric(prometheusExporter);
+                        Boolean enabled = get(metricConfig);
 
-                    if (Boolean.TRUE.equals(enabled)) {
-                        metric.enable();
+                        if (Boolean.TRUE.equals(enabled)) {
+                            metric.enable();
+                        }
+
+                        prometheusExporter.getLogger().fine("Metric " + metricName + " enabled: " + enabled);
+
+                        MetricRegistry.getInstance().register(metric);
+                    } catch (Exception e) {
+                        prometheusExporter.getLogger().warning("Failed to enable metric " + metricName + ": " + e.getMessage());
+                        prometheusExporter.getLogger().log(java.util.logging.Level.FINE, "Failed to enable metric " + metricName, e);
                     }
-
-                    prometheusExporter.getLogger().fine("Metric " + metric.getClass().getSimpleName() + " enabled: " + enabled);
-
-                    MetricRegistry.getInstance().register(metric);
                 });
     }
 


### PR DESCRIPTION
This does not fix the underlying bug (https://github.com/prometheus/client_java/issues/866) but allows the plugin to start without the JVM metrics.

Partially fixes #197.