### PR TITLE
Add support for async metrics, make world size the first async metric

### DIFF
--- a/src/main/java/de/sldk/mc/MetricRegistry.java
+++ b/src/main/java/de/sldk/mc/MetricRegistry.java
@@ -4,6 +4,7 @@ import de.sldk.mc.metrics.Metric;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class MetricRegistry {
 
@@ -23,8 +24,11 @@ public class MetricRegistry {
         this.metrics.add(metric);
     }
 
-    void collectMetrics() {
-        this.metrics.forEach(Metric::collect);
+    CompletableFuture<Void> collectMetrics() {
+        /* Combine all Completable futures into a single one */
+        return CompletableFuture.allOf(this.metrics.stream()
+                .map(Metric::collect)
+                .toArray(CompletableFuture[]::new));
     }
 
 }

--- a/src/main/java/de/sldk/mc/MetricsController.java
+++ b/src/main/java/de/sldk/mc/MetricsController.java
@@ -10,7 +10,6 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.logging.Level;
 
 public class MetricsController extends AbstractHandler {
@@ -31,17 +30,8 @@ public class MetricsController extends AbstractHandler {
             return;
         }
 
-        /*
-         * Bukkit API calls have to be made from the main thread.
-         * That's why we use the BukkitScheduler to retrieve the server stats.
-         * */
-        Future<Object> future = exporter.getServer().getScheduler().callSyncMethod(exporter, () -> {
-            metricRegistry.collectMetrics();
-            return null;
-        });
-
         try {
-            future.get();
+            metricRegistry.collectMetrics().get();
 
             response.setStatus(HttpStatus.OK_200);
             response.setContentType(TextFormat.CONTENT_TYPE_004);

--- a/src/main/java/de/sldk/mc/metrics/Metric.java
+++ b/src/main/java/de/sldk/mc/metrics/Metric.java
@@ -2,8 +2,11 @@ package de.sldk.mc.metrics;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
 public abstract class Metric {
@@ -24,20 +27,53 @@ public abstract class Metric {
         return plugin;
     }
 
-    public void collect() {
+    public CompletableFuture<Void> collect() {
 
         if (!enabled) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
-        try {
-            doCollect();
-        } catch (Exception e) {
-            logException(e);
+        if (isAsyncCapable()) {
+            /* If metric is capable of async execution, do it */
+            return CompletableFuture.runAsync(() -> {
+                try {
+                    doCollect();
+                }
+                catch (Exception e) {
+                    logException(e);
+                }
+            });
         }
+
+        /* Otherwise run the metric on the main thread and create a future for this */
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Bukkit.getScheduler().callSyncMethod(plugin, () -> {
+                    try {
+                        doCollect();
+                    }
+                    catch (Exception e) {
+                        logException(e);
+                    }
+                    return null;
+                }).get();
+            } catch (InterruptedException | ExecutionException e) {
+                logException(e);
+            }
+        });
     }
 
     protected abstract void doCollect();
+
+    /**
+     * This method is called during the Metric collection
+     * to determine if it is safe to do it async.
+     * By default, all Metrics are sync unless this method
+     * is overridden.
+     */
+    protected boolean isAsyncCapable() {
+        return false;
+    }
 
     private void logException(Exception e) {
         final Logger log = plugin.getLogger();

--- a/src/main/java/de/sldk/mc/metrics/WorldSize.java
+++ b/src/main/java/de/sldk/mc/metrics/WorldSize.java
@@ -36,4 +36,9 @@ public class WorldSize extends WorldMetric {
             log.throwing(this.getClass().getSimpleName(), "collect", t);
         }
     }
+
+    @Override
+    protected boolean isAsyncCapable() {
+        return true;
+    }
 }

--- a/src/test/java/de/sldk/mc/exporter/PrometheusExporterTest.java
+++ b/src/test/java/de/sldk/mc/exporter/PrometheusExporterTest.java
@@ -2,8 +2,6 @@ package de.sldk.mc.exporter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import de.sldk.mc.MetricsServer;
 import de.sldk.mc.PrometheusExporter;
@@ -11,8 +9,6 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.exporter.common.TextFormat;
 import io.restassured.RestAssured;
-import org.bukkit.Server;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.URIUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -24,17 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.concurrent.CompletableFuture;
 
 @ExtendWith(MockitoExtension.class)
 public class PrometheusExporterTest {
 
 	@Mock
 	private PrometheusExporter exporterMock;
-	@Mock
-	private Server mockServer;
-	@Mock
-	private BukkitScheduler mockScheduler;
 
 	private int metricsServerPort;
 	private MetricsServer metricsServer;
@@ -60,7 +51,6 @@ public class PrometheusExporterTest {
 
 	@Test
 	void metrics_server_should_return_valid_prometheus_response() {
-		mockBukkitApis();
 		mockPrometheusCounter("mc_mock_metric", "This is a mock metric", 419);
 
 		String requestPath = URIUtil.newURI("http", "localhost", metricsServerPort, "/metrics", null);
@@ -76,12 +66,6 @@ public class PrometheusExporterTest {
 		assertThat(lines[0]).isEqualTo("# HELP mc_mock_metric_total This is a mock metric");
 		assertThat(lines[1]).isEqualTo("# TYPE mc_mock_metric_total counter");
 		assertThat(lines[2]).isEqualTo("mc_mock_metric_total 419.0");
-	}
-
-	private void mockBukkitApis() {
-		when(exporterMock.getServer()).thenReturn(mockServer);
-		when(mockServer.getScheduler()).thenReturn(mockScheduler);
-		when(mockScheduler.callSyncMethod(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
 	}
 
 	private void mockPrometheusCounter(String name, String help, int value) {


### PR DESCRIPTION
Fixes #155

Added support for async metrics. The metrics that can run off the main thread may override `isAsyncCapable` method. Such metrics will be run off the main thread while all other metrics will still get scheduled on the main thread.

Works fine for me with 0 high ticks with this world:
![image](https://github.com/sladkoff/minecraft-prometheus-exporter/assets/43506080/6227c28d-804b-454f-9593-fb85900918a8)
