### PR TITLE
Do not pin threads when handling sync metrics

### DIFF
--- a/src/main/java/de/sldk/mc/MetricRegistry.java
+++ b/src/main/java/de/sldk/mc/MetricRegistry.java
@@ -4,6 +4,7 @@ import de.sldk.mc.metrics.Metric;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 public class MetricRegistry {
@@ -28,6 +29,7 @@ public class MetricRegistry {
         /* Combine all Completable futures into a single one */
         return CompletableFuture.allOf(this.metrics.stream()
                 .map(Metric::collect)
+                .filter(Objects::nonNull)
                 .toArray(CompletableFuture[]::new));
     }
 

--- a/src/main/java/de/sldk/mc/metrics/Metric.java
+++ b/src/main/java/de/sldk/mc/metrics/Metric.java
@@ -2,12 +2,13 @@ package de.sldk.mc.metrics;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
+import org.bukkit.scheduler.BukkitTask;
+import org.checkerframework.checker.units.qual.C;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class Metric {
 
@@ -27,42 +28,36 @@ public abstract class Metric {
         return plugin;
     }
 
+    @Nullable
     public CompletableFuture<Void> collect() {
-        return CompletableFuture.runAsync(() -> {
-            if (!enabled) {
-                return;
-            }
+        if (!isEnabled()) {
+            return null;
+        }
 
-            /* If metric is capable of async execution run it on a thread pool */
-            if (isAsyncCapable()) {
-
+        if (isAsyncCapable()) {
+            CompletableFuture.runAsync(() -> {
                 try {
                     doCollect();
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     logException(e);
                 }
-                return;
-            }
+            });
+        }
 
-            /*
-            * Otherwise run the metric on the main thread and make the
-            * thread on thread pool wait for completion
-            */
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // don't call .get() - this blocks the ForkJoinPool.commonPool and may deadlock the server in some cases
+        Bukkit.getScheduler().callSyncMethod(plugin, () -> {
             try {
-                Bukkit.getScheduler().callSyncMethod(plugin, () -> {
-                    try {
-                        doCollect();
-                    }
-                    catch (Exception e) {
-                        logException(e);
-                    }
-                    return null;
-                }).get();
+                doCollect();
             } catch (Exception e) {
                 logException(e);
             }
+            future.complete(null);
+            return null;
         });
+
+        return future;
     }
 
     protected abstract void doCollect();

--- a/src/main/java/de/sldk/mc/metrics/Metric.java
+++ b/src/main/java/de/sldk/mc/metrics/Metric.java
@@ -6,8 +6,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
-import org.checkerframework.checker.units.qual.C;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class Metric {


### PR DESCRIPTION
The current implementation of `Metric#collect` for non-async-capable metrics is flawed:
```java
Bukkit.getScheduler().callSyncMethod(plugin, () -> {
    try {
        doCollect();
    }
    catch (Exception e) {
        logException(e);
    }
    return null;
}).get();
```

`get()` is implemented in Bukkit with `Object#wait`. It is not advisable to ever call this method from an `Executor`, since low level synchronization primitives typically pin the thread. For instance, this will cause a deadlock with CommandAPI, since CommandAPI's reloading mechanism will dispatch some tasks to `ForkJoinPool.commonPool()`. In the case that all threads are pinned by this plugin, CommandAPI never finishes reloading datapacks and thus blocks the main thread forever (which means `callSyncTask`'s future never completes).

Instead of waiting, we can simply construct a `CompletableFuture` which is completed whenever the metric is done collecting.